### PR TITLE
Moves table of contents to LHS

### DIFF
--- a/src/main.adoc
+++ b/src/main.adoc
@@ -11,7 +11,7 @@ The PartiQL Specification Committee
 :sectanchors:
 :sectlinks:
 :sectnumlevels: 5
-:toc:
+:toc: left
 :toclevels: 4
 :toc-title: Contents
 :pagenums:


### PR DESCRIPTION
Moves table of contents to LHS for HTML when page is large enough.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
